### PR TITLE
fix: mlr3verse_info() now prints version of mlr3

### DIFF
--- a/R/mlr3verse_info.R
+++ b/R/mlr3verse_info.R
@@ -13,6 +13,7 @@ mlr3verse_info = function() {
   imports = strsplit(imports, ",[[:space:]]*")[[1L]]
   imports = sub("^([[:alnum:].]+).*", "\\1", imports)
   imports = setdiff(imports, "data.table")
+  imports = unique(c("mlr3", imports))
 
   data.table(package = imports, version = map_chr(imports, function(x) {
     as.character(utils::packageVersion(x))


### PR DESCRIPTION
Fixes #37

``` r
library(mlr3verse)
#> Loading required package: mlr3

mlr3verse_info()
#> Key: <package>
#>              package    version
#>               <char>     <char>
#>  1:            bbotk      1.0.1
#>  2:             mlr3     0.20.2
#>  3:      mlr3cluster      0.1.9
#>  4:         mlr3data      0.7.0
#>  5:      mlr3filters 0.8.0.9000
#>  6:      mlr3fselect      1.0.0
#>  7:    mlr3hyperband      0.6.0
#>  8:     mlr3learners      0.7.0
#>  9:          mlr3mbo      0.2.4
#> 10:         mlr3misc     0.15.1
#> 11:    mlr3pipelines      0.6.0
#> 12:       mlr3tuning      1.0.0
#> 13: mlr3tuningspaces 0.5.1.9000
#> 14:          mlr3viz 0.9.0.9000
#> 15:          paradox      1.0.1
```

<sup>Created on 2024-08-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>